### PR TITLE
Add max_output_size config field

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If the command exits, it is restarted after a configurable delay.
 | `exec_timeout` | `duration` | `0` (none) | Maximum duration for a scheduled execution. Process is killed if exceeded. Only used in scheduled mode. |
 | `include_stderr` | `bool` | `true` | Whether to capture stderr output alongside stdout. |
 | `max_buffer_size` | `int` | `1048576` (1MB) | Maximum buffer size in bytes for reading a single line of output. |
+| `max_output_size` | `int` | `10485760` (10MB) | Maximum total bytes buffered per scheduled execution. Output is truncated when exceeded. `0` means no limit. Must be >= `max_buffer_size` when set. Only used in scheduled mode. |
 | `environment` | `map[string]string` | `{}` | Environment variables to set for the command. |
 | `working_directory` | `string` | *(inherit)* | Working directory for the command. |
 | `inherit_environment` | `bool` | `false` | If true, inherits the collector's environment as a base. When false (default), starts with a clean environment. `environment` entries are always added. |

--- a/config.go
+++ b/config.go
@@ -61,6 +61,12 @@ type Config struct {
 	// Default: false (start with a clean environment).
 	InheritEnvironment bool `mapstructure:"inherit_environment"`
 
+	// MaxOutputSize is the maximum total bytes buffered per scheduled
+	// execution in readLines. When exceeded, reading stops and the
+	// output is truncated. Default: 10485760 (10MB). 0 means no limit.
+	// Only used in scheduled mode.
+	MaxOutputSize int `mapstructure:"max_output_size"`
+
 	// RestartDelay is the delay before restarting a streaming command
 	// that has exited. Default: 1s. Only used in streaming mode.
 	RestartDelay time.Duration `mapstructure:"restart_delay"`
@@ -71,6 +77,7 @@ var (
 	errInvalidMode           = errors.New("mode must be 'scheduled' or 'streaming'")
 	errIntervalTooSmall      = errors.New("interval must be at least 1s")
 	errMaxBufferSizeTooSmall = errors.New("max_buffer_size must be at least 1024 bytes")
+	errMaxOutputSizeTooSmall = errors.New("max_output_size must be >= max_buffer_size when set")
 	errRestartDelayNegative  = errors.New("restart_delay must not be negative")
 )
 
@@ -92,6 +99,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.MaxBufferSize < 1024 {
 		errs = multierr.Append(errs, errMaxBufferSizeTooSmall)
+	}
+
+	if cfg.MaxOutputSize > 0 && cfg.MaxOutputSize < cfg.MaxBufferSize {
+		errs = multierr.Append(errs, errMaxOutputSizeTooSmall)
 	}
 
 	if cfg.RestartDelay < 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -89,6 +89,37 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: "max_buffer_size must be at least 1024 bytes",
 		},
 		{
+			name: "max_output_size valid when equal to max_buffer_size",
+			cfg: &Config{
+				Command:       []string{"echo", "hello"},
+				Mode:          ModeScheduled,
+				Interval:      60 * time.Second,
+				MaxBufferSize: 1024 * 1024,
+				MaxOutputSize: 1024 * 1024,
+			},
+		},
+		{
+			name: "max_output_size valid when zero (unlimited)",
+			cfg: &Config{
+				Command:       []string{"echo", "hello"},
+				Mode:          ModeScheduled,
+				Interval:      60 * time.Second,
+				MaxBufferSize: 1024 * 1024,
+				MaxOutputSize: 0,
+			},
+		},
+		{
+			name: "max_output_size too small",
+			cfg: &Config{
+				Command:       []string{"echo"},
+				Mode:          ModeScheduled,
+				Interval:      60 * time.Second,
+				MaxBufferSize: 1024 * 1024,
+				MaxOutputSize: 1024,
+			},
+			wantErr: "max_output_size must be >= max_buffer_size when set",
+		},
+		{
 			name: "negative restart delay",
 			cfg: &Config{
 				Command:       []string{"echo"},
@@ -151,6 +182,7 @@ func TestConfigLoadFromYAML(t *testing.T) {
 				Interval:      10 * time.Second,
 				IncludeStderr: true,
 				MaxBufferSize: 1024 * 1024,
+				MaxOutputSize: 10 * 1024 * 1024,
 				RestartDelay:  time.Second,
 			},
 		},
@@ -163,6 +195,7 @@ func TestConfigLoadFromYAML(t *testing.T) {
 				RestartDelay:       2 * time.Second,
 				IncludeStderr:      false,
 				MaxBufferSize:      2097152,
+				MaxOutputSize:      10 * 1024 * 1024,
 				Environment:        map[string]string{"FOO": "bar"},
 				WorkingDirectory:   "/tmp",
 				InheritEnvironment: false,
@@ -177,6 +210,7 @@ func TestConfigLoadFromYAML(t *testing.T) {
 				ExecTimeout:        10 * time.Second,
 				IncludeStderr:      true,
 				MaxBufferSize:      524288,
+				MaxOutputSize:      5242880,
 				Environment:        map[string]string{"ENV1": "value1", "ENV2": "value2"},
 				WorkingDirectory:   "/tmp",
 				InheritEnvironment: true,

--- a/factory.go
+++ b/factory.go
@@ -28,7 +28,8 @@ func createDefaultConfig() component.Config {
 		Mode:          ModeScheduled,
 		Interval:      60 * time.Second,
 		IncludeStderr: true,
-		MaxBufferSize: 1024 * 1024, // 1MB
+		MaxBufferSize: 1024 * 1024,      // 1MB
+		MaxOutputSize: 10 * 1024 * 1024, // 10MB
 		RestartDelay:  time.Second,
 	}
 }

--- a/receiver.go
+++ b/receiver.go
@@ -343,14 +343,26 @@ func (r *execReceiver) streamLines(ctx context.Context, reader io.Reader, stream
 }
 
 // readLines reads all lines from a reader and returns them.
+// If max_output_size is set, reading stops once that many bytes have been
+// consumed and a warning is logged.
 func (r *execReceiver) readLines(reader io.Reader, stream string) []outputLine {
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(make([]byte, 0, r.cfg.MaxBufferSize), r.cfg.MaxBufferSize)
 
 	var lines []outputLine
+	var totalBytes int
 	for scanner.Scan() {
+		text := scanner.Text()
+		// Account for the line content plus a newline byte.
+		totalBytes += len(text) + 1
+		if r.cfg.MaxOutputSize > 0 && totalBytes > r.cfg.MaxOutputSize {
+			r.logger.Warn("Output truncated: max_output_size exceeded",
+				zap.String("stream", stream),
+				zap.Int("max_output_size", r.cfg.MaxOutputSize))
+			break
+		}
 		lines = append(lines, outputLine{
-			text:      scanner.Text(),
+			text:      text,
 			stream:    stream,
 			timestamp: time.Now(),
 		})

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -366,6 +366,81 @@ func TestWorkingDirectory(t *testing.T) {
 	assert.True(t, body == "/tmp" || body == "/private/tmp", "unexpected working directory: %s", body)
 }
 
+func TestScheduledMaxOutputSize(t *testing.T) {
+	// Generate output that exceeds the max_output_size limit.
+	// Each line is "line_NNN\n" = 9 bytes. With max_output_size=50,
+	// we can fit about 5 lines (5*9=45 <= 50), and the 6th (54) exceeds it.
+	cfg := &Config{
+		Command:       []string{"sh", "-c", "for i in $(seq -w 1 20); do echo line_$i; done"},
+		Mode:          ModeScheduled,
+		Interval:      time.Hour,
+		IncludeStderr: true,
+		MaxBufferSize: 1024,
+		MaxOutputSize: 50,
+		RestartDelay:  time.Second,
+	}
+	r, sink := newTestReceiver(t, cfg)
+
+	require.NoError(t, r.Start(context.Background(), nil))
+	t.Cleanup(func() { require.NoError(t, r.Shutdown(context.Background())) })
+
+	require.Eventually(t, func() bool {
+		return sink.LogRecordCount() > 0
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// Should have fewer than 20 lines due to truncation
+	var bodies []string
+	for _, ld := range sink.AllLogs() {
+		for i := 0; i < ld.ResourceLogs().Len(); i++ {
+			rl := ld.ResourceLogs().At(i)
+			for j := 0; j < rl.ScopeLogs().Len(); j++ {
+				sl := rl.ScopeLogs().At(j)
+				for k := 0; k < sl.LogRecords().Len(); k++ {
+					bodies = append(bodies, sl.LogRecords().At(k).Body().Str())
+				}
+			}
+		}
+	}
+
+	assert.Greater(t, len(bodies), 0, "should have at least one line")
+	assert.Less(t, len(bodies), 20, "output should be truncated before all 20 lines")
+}
+
+func TestScheduledMaxOutputSizeUnlimited(t *testing.T) {
+	// When max_output_size is 0, all output should be captured.
+	cfg := &Config{
+		Command:       []string{"sh", "-c", "for i in 1 2 3 4 5; do echo line$i; done"},
+		Mode:          ModeScheduled,
+		Interval:      time.Hour,
+		IncludeStderr: true,
+		MaxBufferSize: 1024,
+		MaxOutputSize: 0, // unlimited
+		RestartDelay:  time.Second,
+	}
+	r, sink := newTestReceiver(t, cfg)
+
+	require.NoError(t, r.Start(context.Background(), nil))
+	t.Cleanup(func() { require.NoError(t, r.Shutdown(context.Background())) })
+
+	require.Eventually(t, func() bool {
+		return sink.LogRecordCount() >= 5
+	}, 5*time.Second, 50*time.Millisecond)
+
+	var bodies []string
+	for _, ld := range sink.AllLogs() {
+		for i := 0; i < ld.ResourceLogs().Len(); i++ {
+			rl := ld.ResourceLogs().At(i)
+			for j := 0; j < rl.ScopeLogs().Len(); j++ {
+				sl := rl.ScopeLogs().At(j)
+				for k := 0; k < sl.LogRecords().Len(); k++ {
+					bodies = append(bodies, sl.LogRecords().At(k).Body().Str())
+				}
+			}
+		}
+	}
+	assert.Equal(t, 5, len(bodies), "all 5 lines should be captured when unlimited")
+}
+
 func TestScheduledInterval(t *testing.T) {
 	cfg := &Config{
 		Command:       []string{"echo", "tick"},

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -21,6 +21,7 @@ exec/full:
   exec_timeout: 10s
   include_stderr: true
   max_buffer_size: 524288
+  max_output_size: 5242880
   environment:
     ENV1: value1
     ENV2: value2


### PR DESCRIPTION
## Summary
- Add `max_output_size` config field (int, default 10MB) that caps total bytes buffered per scheduled execution
- When exceeded, reading stops early and a warning is logged
- Validation: must be >= `max_buffer_size` when set; `0` means unlimited

## Test plan
- [x] Config validation tests for new field
- [x] Receiver test: output truncated when limit exceeded
- [x] Receiver test: all output captured when unlimited
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)