### PR TITLE
Add exponential backoff for streaming mode restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Each execution produces a batch of log records from the command's output. If the
 ### Streaming
 
 Runs the command continuously and reads output line-by-line as it is produced.
-If the command exits, it is restarted after a configurable delay.
+If the command exits, it is restarted after a configurable delay with exponential backoff.
+The backoff starts at `restart_delay`, doubles on each consecutive failure, and caps at `max_restart_delay`.
+It resets when the command runs successfully for longer than `restart_delay`.
 
 ## Configuration
 
@@ -46,7 +48,8 @@ If the command exits, it is restarted after a configurable delay.
 | `environment` | `map[string]string` | `{}` | Environment variables to set for the command. |
 | `working_directory` | `string` | *(inherit)* | Working directory for the command. |
 | `inherit_environment` | `bool` | `false` | If true, inherits the collector's environment as a base. When false (default), starts with a clean environment. `environment` entries are always added. |
-| `restart_delay` | `duration` | `1s` | Delay before restarting a streaming command that has exited. Only used in streaming mode. |
+| `restart_delay` | `duration` | `1s` | Initial delay before restarting a streaming command that has exited. Doubles on each consecutive failure (exponential backoff), capped at `max_restart_delay`. Resets after the command runs longer than `restart_delay`. Only used in streaming mode. |
+| `max_restart_delay` | `duration` | `5m` | Maximum backoff delay for streaming command restarts. Must be >= `restart_delay`. Only used in streaming mode. |
 
 ### Example: Scheduled
 
@@ -140,7 +143,7 @@ are also available via the built-in `ObsReport` instrumentation.
 
 - **Graceful shutdown**: On shutdown, the receiver sends `SIGINT` to running processes, then `SIGKILL` after 5 seconds if the process hasn't exited.
 - **Scheduled mode**: Each execution runs independently. If `exec_timeout` is set, the process is killed if it exceeds the timeout.
-- **Streaming mode**: The command runs continuously. If it exits, the receiver waits `restart_delay` before restarting. The restart counter metric tracks how many times a streaming command has been restarted.
+- **Streaming mode**: The command runs continuously. If it exits, the receiver waits before restarting with exponential backoff (starting at `restart_delay`, doubling on each consecutive failure, capped at `max_restart_delay`). The backoff resets when the command runs longer than `restart_delay`. The restart counter metric tracks how many times a streaming command has been restarted.
 - **Environment**: By default, commands start with a clean environment. Use `environment` to set variables, or `inherit_environment: true` to inherit the collector's environment as a base.
 
 ### Audit Logging

--- a/config.go
+++ b/config.go
@@ -70,15 +70,21 @@ type Config struct {
 	// RestartDelay is the delay before restarting a streaming command
 	// that has exited. Default: 1s. Only used in streaming mode.
 	RestartDelay time.Duration `mapstructure:"restart_delay"`
+
+	// MaxRestartDelay is the maximum backoff delay for streaming command
+	// restarts. The restart delay doubles on each consecutive failure,
+	// capped at this value. Default: 5m. Only used in streaming mode.
+	MaxRestartDelay time.Duration `mapstructure:"max_restart_delay"`
 }
 
 var (
-	errEmptyCommand          = errors.New("command must not be empty")
-	errInvalidMode           = errors.New("mode must be 'scheduled' or 'streaming'")
-	errIntervalTooSmall      = errors.New("interval must be at least 1s")
-	errMaxBufferSizeTooSmall = errors.New("max_buffer_size must be at least 1024 bytes")
-	errMaxOutputSizeTooSmall = errors.New("max_output_size must be >= max_buffer_size when set")
-	errRestartDelayNegative  = errors.New("restart_delay must not be negative")
+	errEmptyCommand            = errors.New("command must not be empty")
+	errInvalidMode             = errors.New("mode must be 'scheduled' or 'streaming'")
+	errIntervalTooSmall        = errors.New("interval must be at least 1s")
+	errMaxBufferSizeTooSmall   = errors.New("max_buffer_size must be at least 1024 bytes")
+	errMaxOutputSizeTooSmall   = errors.New("max_output_size must be >= max_buffer_size when set")
+	errRestartDelayNegative    = errors.New("restart_delay must not be negative")
+	errMaxRestartDelayTooSmall = errors.New("max_restart_delay must be >= restart_delay")
 )
 
 // Validate checks the configuration for errors.
@@ -107,6 +113,10 @@ func (cfg *Config) Validate() error {
 
 	if cfg.RestartDelay < 0 {
 		errs = multierr.Append(errs, errRestartDelayNegative)
+	}
+
+	if cfg.MaxRestartDelay > 0 && cfg.MaxRestartDelay < cfg.RestartDelay {
+		errs = multierr.Append(errs, errMaxRestartDelayTooSmall)
 	}
 
 	if cfg.WorkingDirectory != "" {

--- a/config_test.go
+++ b/config_test.go
@@ -131,6 +131,40 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: "restart_delay must not be negative",
 		},
 		{
+			name: "max_restart_delay less than restart_delay",
+			cfg: &Config{
+				Command:         []string{"tail", "-f", "/dev/null"},
+				Mode:            ModeStreaming,
+				Interval:        60 * time.Second,
+				MaxBufferSize:   1024 * 1024,
+				RestartDelay:    10 * time.Second,
+				MaxRestartDelay: 5 * time.Second,
+			},
+			wantErr: "max_restart_delay must be >= restart_delay",
+		},
+		{
+			name: "valid max_restart_delay",
+			cfg: &Config{
+				Command:         []string{"tail", "-f", "/dev/null"},
+				Mode:            ModeStreaming,
+				Interval:        60 * time.Second,
+				MaxBufferSize:   1024 * 1024,
+				RestartDelay:    time.Second,
+				MaxRestartDelay: 5 * time.Minute,
+			},
+		},
+		{
+			name: "max_restart_delay zero uses no cap",
+			cfg: &Config{
+				Command:         []string{"tail", "-f", "/dev/null"},
+				Mode:            ModeStreaming,
+				Interval:        60 * time.Second,
+				MaxBufferSize:   1024 * 1024,
+				RestartDelay:    time.Second,
+				MaxRestartDelay: 0,
+			},
+		},
+		{
 			name: "non-existent working directory",
 			cfg: &Config{
 				Command:          []string{"echo"},
@@ -177,13 +211,14 @@ func TestConfigLoadFromYAML(t *testing.T) {
 		{
 			id: component.NewID(component.MustNewType("exec")),
 			expected: &Config{
-				Command:       []string{"echo", "hello"},
-				Mode:          ModeScheduled,
-				Interval:      10 * time.Second,
-				IncludeStderr: true,
-				MaxBufferSize: 1024 * 1024,
-				MaxOutputSize: 10 * 1024 * 1024,
-				RestartDelay:  time.Second,
+				Command:         []string{"echo", "hello"},
+				Mode:            ModeScheduled,
+				Interval:        10 * time.Second,
+				IncludeStderr:   true,
+				MaxBufferSize:   1024 * 1024,
+				MaxOutputSize:   10 * 1024 * 1024,
+				RestartDelay:    time.Second,
+				MaxRestartDelay: 5 * time.Minute,
 			},
 		},
 		{
@@ -193,6 +228,7 @@ func TestConfigLoadFromYAML(t *testing.T) {
 				Mode:               ModeStreaming,
 				Interval:           60 * time.Second,
 				RestartDelay:       2 * time.Second,
+				MaxRestartDelay:    10 * time.Second,
 				IncludeStderr:      false,
 				MaxBufferSize:      2097152,
 				MaxOutputSize:      10 * 1024 * 1024,
@@ -215,6 +251,7 @@ func TestConfigLoadFromYAML(t *testing.T) {
 				WorkingDirectory:   "/tmp",
 				InheritEnvironment: true,
 				RestartDelay:       5 * time.Second,
+				MaxRestartDelay:    30 * time.Second,
 			},
 		},
 	}

--- a/factory.go
+++ b/factory.go
@@ -25,12 +25,13 @@ func NewFactory() receiver.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Mode:          ModeScheduled,
-		Interval:      60 * time.Second,
-		IncludeStderr: true,
-		MaxBufferSize: 1024 * 1024,      // 1MB
-		MaxOutputSize: 10 * 1024 * 1024, // 10MB
-		RestartDelay:  time.Second,
+		Mode:            ModeScheduled,
+		Interval:        60 * time.Second,
+		IncludeStderr:   true,
+		MaxBufferSize:   1024 * 1024,      // 1MB
+		MaxOutputSize:   10 * 1024 * 1024, // 10MB
+		RestartDelay:    time.Second,
+		MaxRestartDelay: 5 * time.Minute,
 	}
 }
 

--- a/receiver.go
+++ b/receiver.go
@@ -219,8 +219,13 @@ func (r *execReceiver) executeOnce(ctx context.Context) {
 }
 
 // runStreaming runs the command continuously, restarting on exit.
+// It uses exponential backoff: the restart delay starts at RestartDelay,
+// doubles on each consecutive failure, and caps at MaxRestartDelay.
+// The backoff resets when the command runs longer than RestartDelay.
 func (r *execReceiver) runStreaming(ctx context.Context) {
 	defer r.wg.Done()
+
+	currentDelay := r.cfg.RestartDelay
 
 	for {
 		select {
@@ -230,15 +235,30 @@ func (r *execReceiver) runStreaming(ctx context.Context) {
 		}
 
 		r.telemetry.ExecReceiverExecutions.Add(ctx, 1)
+		start := time.Now()
 		r.streamCommand(ctx)
+		elapsed := time.Since(start)
+
+		// Reset backoff if the command ran successfully for longer than
+		// the base restart delay (i.e., it didn't immediately crash).
+		if elapsed > r.cfg.RestartDelay {
+			currentDelay = r.cfg.RestartDelay
+		}
 
 		// Check if we should stop before restarting.
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(r.cfg.RestartDelay):
-			r.logger.Info("Restarting streaming command")
+		case <-time.After(currentDelay):
+			r.logger.Info("Restarting streaming command",
+				zap.Duration("backoff", currentDelay))
 			r.telemetry.ExecReceiverRestarts.Add(ctx, 1)
+		}
+
+		// Increase backoff for next restart (exponential).
+		currentDelay *= 2
+		if r.cfg.MaxRestartDelay > 0 && currentDelay > r.cfg.MaxRestartDelay {
+			currentDelay = r.cfg.MaxRestartDelay
 		}
 	}
 }

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -5,6 +5,7 @@ package execreceiver
 
 import (
 	"context"
+	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -207,11 +208,12 @@ func TestScheduledTimeout(t *testing.T) {
 
 func TestStreamingBasic(t *testing.T) {
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "for i in 1 2 3; do echo line$i; done"},
-		Mode:          ModeStreaming,
-		IncludeStderr: true,
-		MaxBufferSize: 1024 * 1024,
-		RestartDelay:  time.Hour, // don't restart during test
+		Command:         []string{"sh", "-c", "for i in 1 2 3; do echo line$i; done"},
+		Mode:            ModeStreaming,
+		IncludeStderr:   true,
+		MaxBufferSize:   1024 * 1024,
+		RestartDelay:    time.Hour, // don't restart during test
+		MaxRestartDelay: time.Hour,
 	}
 	r, sink := newTestReceiver(t, cfg)
 
@@ -241,11 +243,12 @@ func TestStreamingBasic(t *testing.T) {
 
 func TestStreamingRestart(t *testing.T) {
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "echo restarted; exit 0"},
-		Mode:          ModeStreaming,
-		IncludeStderr: true,
-		MaxBufferSize: 1024 * 1024,
-		RestartDelay:  100 * time.Millisecond,
+		Command:         []string{"sh", "-c", "echo restarted; exit 0"},
+		Mode:            ModeStreaming,
+		IncludeStderr:   true,
+		MaxBufferSize:   1024 * 1024,
+		RestartDelay:    100 * time.Millisecond,
+		MaxRestartDelay: 100 * time.Millisecond, // cap at restart_delay to keep restarts fast
 	}
 	r, sink := newTestReceiver(t, cfg)
 
@@ -459,6 +462,130 @@ func TestScheduledInterval(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return sink.LogRecordCount() >= 3
 	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestStreamingBackoffIncreasesOnRapidFailures(t *testing.T) {
+	// Use a command that exits immediately to trigger rapid failures.
+	// With restart_delay=50ms and max_restart_delay=200ms, the delays should be:
+	//   50ms, 100ms, 200ms (capped), 200ms, ...
+	// After 3 restarts (50+100+200=350ms minimum), we check timing.
+	cfg := &Config{
+		Command:         []string{"sh", "-c", "echo backoff; exit 1"},
+		Mode:            ModeStreaming,
+		IncludeStderr:   true,
+		MaxBufferSize:   1024 * 1024,
+		RestartDelay:    50 * time.Millisecond,
+		MaxRestartDelay: 200 * time.Millisecond,
+	}
+	r, sink := newTestReceiver(t, cfg)
+
+	require.NoError(t, r.Start(context.Background(), nil))
+	t.Cleanup(func() { require.NoError(t, r.Shutdown(context.Background())) })
+
+	start := time.Now()
+
+	// Wait for at least 4 executions (initial + 3 restarts).
+	// With backoff: 0 + 50ms + 100ms + 200ms = 350ms minimum before 4th execution starts.
+	require.Eventually(t, func() bool {
+		return sink.LogRecordCount() >= 4
+	}, 5*time.Second, 10*time.Millisecond)
+
+	elapsed := time.Since(start)
+
+	// The total delay for 3 restarts should be at least 350ms (50+100+200).
+	// Without backoff it would be 150ms (3*50ms).
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(300),
+		"backoff should cause restarts to take longer than without backoff")
+}
+
+func TestStreamingBackoffResetsAfterSuccessfulRun(t *testing.T) {
+	// This test uses a command that:
+	// 1. First run: exits immediately (triggers backoff increase to 100ms)
+	// 2. Second run: sleeps for 200ms (longer than restart_delay=50ms), then exits
+	//    -> backoff should reset to 50ms
+	// 3. Third run: exits immediately again
+	// 4. Fourth run: exits immediately again
+	//
+	// If backoff reset works, runs 3+4 happen with short delays (50ms, 100ms).
+	// If backoff did NOT reset, run 3 would wait 200ms (doubled from 100ms).
+	//
+	// We verify by checking total time: with reset the total is roughly
+	// 50ms + 200ms + 50ms + 100ms = 400ms (plus execution time).
+	// Without reset it would be 50ms + 200ms + 200ms + 400ms = 850ms+.
+	//
+	// We use a state file to track which run we're on.
+	cfg := &Config{
+		Command: []string{"sh", "-c", `
+			if [ ! -f /tmp/execreceiver_backoff_test ]; then
+				echo "run1-fail"
+				touch /tmp/execreceiver_backoff_test
+				exit 1
+			elif [ ! -f /tmp/execreceiver_backoff_test2 ]; then
+				echo "run2-success"
+				touch /tmp/execreceiver_backoff_test2
+				sleep 0.2
+				exit 0
+			elif [ ! -f /tmp/execreceiver_backoff_test3 ]; then
+				echo "run3-after-reset"
+				touch /tmp/execreceiver_backoff_test3
+				exit 1
+			else
+				echo "run4-done"
+				exit 1
+			fi
+		`},
+		Mode:            ModeStreaming,
+		IncludeStderr:   true,
+		MaxBufferSize:   1024 * 1024,
+		RestartDelay:    50 * time.Millisecond,
+		MaxRestartDelay: 5 * time.Second,
+	}
+
+	// Clean up state files before test.
+	_ = os.Remove("/tmp/execreceiver_backoff_test")
+	_ = os.Remove("/tmp/execreceiver_backoff_test2")
+	_ = os.Remove("/tmp/execreceiver_backoff_test3")
+	t.Cleanup(func() {
+		_ = os.Remove("/tmp/execreceiver_backoff_test")
+		_ = os.Remove("/tmp/execreceiver_backoff_test2")
+		_ = os.Remove("/tmp/execreceiver_backoff_test3")
+	})
+
+	r, sink := newTestReceiver(t, cfg)
+
+	start := time.Now()
+	require.NoError(t, r.Start(context.Background(), nil))
+	t.Cleanup(func() { require.NoError(t, r.Shutdown(context.Background())) })
+
+	// Wait for all 4 runs to complete.
+	require.Eventually(t, func() bool {
+		return sink.LogRecordCount() >= 4
+	}, 10*time.Second, 10*time.Millisecond)
+
+	elapsed := time.Since(start)
+
+	var bodies []string
+	for _, ld := range sink.AllLogs() {
+		for i := 0; i < ld.ResourceLogs().Len(); i++ {
+			rl := ld.ResourceLogs().At(i)
+			for j := 0; j < rl.ScopeLogs().Len(); j++ {
+				sl := rl.ScopeLogs().At(j)
+				for k := 0; k < sl.LogRecords().Len(); k++ {
+					bodies = append(bodies, sl.LogRecords().At(k).Body().Str())
+				}
+			}
+		}
+	}
+
+	assert.Contains(t, bodies, "run1-fail")
+	assert.Contains(t, bodies, "run2-success")
+	assert.Contains(t, bodies, "run3-after-reset")
+	assert.Contains(t, bodies, "run4-done")
+
+	// With backoff reset, total should be well under 2s.
+	// Without reset, the accumulated backoff would be much larger.
+	assert.Less(t, elapsed.Milliseconds(), int64(2000),
+		"backoff should have reset after the successful long-running command")
 }
 
 func TestAuditLogScheduled(t *testing.T) {

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -7,6 +7,7 @@ exec/streaming:
   command: ["tail", "-f", "/dev/null"]
   mode: streaming
   restart_delay: 2s
+  max_restart_delay: 10s
   include_stderr: false
   max_buffer_size: 2097152
   environment:
@@ -28,3 +29,4 @@ exec/full:
   working_directory: /tmp
   inherit_environment: true
   restart_delay: 5s
+  max_restart_delay: 30s


### PR DESCRIPTION
## Summary
- Implement exponential backoff for streaming mode restarts: delay starts at `restart_delay`, doubles on each failure, caps at new `max_restart_delay` config field (default 5m)
- Reset backoff when command runs successfully longer than `restart_delay`
- Log the current backoff delay at each restart

## Test plan
- [x] Config validation: `max_restart_delay < restart_delay` rejected
- [x] Receiver test: backoff increases on rapid failures
- [x] Receiver test: backoff resets after successful run
- [x] `go test ./...` passes
- [x] `go vet ./...` passes

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)