### PR TITLE
Add CI checks for compiled workflow lock files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,37 @@ jobs:
       - name: Check go.mod and go.sum are tidy
         run: git diff --exit-code go.mod go.sum
 
+  check-workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check compiled workflows match source
+        run: |
+          status=0
+          for md in .github/workflows/*.md; do
+            lock="${md%.md}.lock.yml"
+            if [ ! -f "$lock" ]; then
+              echo "error: $md has no compiled lock file: $lock"
+              status=1
+              continue
+            fi
+            # Verify source reference in lock file matches the md frontmatter
+            source=$(sed -n 's/^source: *//p' "$md")
+            if [ -n "$source" ]; then
+              if ! grep -q "# Source: $source" "$lock"; then
+                echo "error: $lock source does not match $md (expected: $source)"
+                status=1
+              fi
+            fi
+          done
+          exit $status
+      - name: Check patch-lock.sh is idempotent
+        run: |
+          for lock in .github/workflows/*.lock.yml; do
+            .github/workflows/patch-lock.sh "$lock"
+          done
+          git diff --exit-code .github/workflows/*.lock.yml
+
   benchmark:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
This PR adds a new CI job to validate that compiled workflow lock files are properly maintained and match their source definitions.

## Key Changes
- Added `check-workflows` CI job that runs on every push to verify workflow integrity
- Implements two validation checks:
  1. **Source reference validation**: Ensures each workflow markdown file (`.md`) has a corresponding compiled lock file (`.lock.yml`) and that the lock file's source reference matches the markdown file's frontmatter
  2. **Idempotency check**: Verifies that running `patch-lock.sh` on all lock files produces no changes, ensuring the build process is deterministic and reproducible

## Implementation Details
- The job iterates through all markdown workflow files in `.github/workflows/`
- For each markdown file, it validates the existence of a corresponding lock file
- It extracts the source reference from the markdown frontmatter and confirms it matches the lock file's source comment
- The `patch-lock.sh` script is run against all lock files to ensure they remain unchanged (idempotent operation)
- The job fails with appropriate error messages if any validation fails, preventing lock file drift

https://claude.ai/code/session_01LYfeGXhWN49yNtFENuD5TT