### PR TITLE
Add automated release workflow for version tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait for CI checks to pass
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const ref = context.sha;
+            const maxWaitMs = 30 * 60 * 1000;
+            const pollInterval = 30 * 1000;
+            const start = Date.now();
+
+            while (true) {
+              if (Date.now() - start > maxWaitMs) {
+                core.setFailed('Timed out waiting for CI checks to complete');
+                return;
+              }
+
+              const { data } = await github.rest.checks.listForRef({
+                owner, repo, ref,
+                per_page: 100,
+              });
+
+              const runs = data.check_runs.filter(r => r.name !== 'release');
+              const incomplete = runs.filter(r => r.status !== 'completed');
+              const failed = runs.filter(r =>
+                r.status === 'completed' &&
+                !['success', 'skipped', 'neutral'].includes(r.conclusion)
+              );
+
+              console.log(`Checks: ${runs.length} total, ${incomplete.length} pending, ${failed.length} failed`);
+
+              if (failed.length > 0) {
+                core.setFailed(`CI checks failed: ${failed.map(r => r.name).join(', ')}`);
+                return;
+              }
+
+              if (incomplete.length === 0 && runs.length > 0) {
+                console.log('All CI checks passed!');
+                break;
+              }
+
+              await new Promise(resolve => setTimeout(resolve, pollInterval));
+            }
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --generate-notes \
+            --title "${{ github.ref_name }}"


### PR DESCRIPTION
## Summary
This PR introduces an automated GitHub Actions workflow that creates releases when version tags are pushed to the repository.

## Key Changes
- Added `.github/workflows/release.yaml` workflow that triggers on version tags (`v*`)
- Implements a CI check validation step that:
  - Polls GitHub's checks API to ensure all CI checks pass before proceeding
  - Waits up to 30 minutes for checks to complete
  - Fails the release if any checks fail or timeout
- Automatically creates a GitHub Release with:
  - Auto-generated release notes
  - Tag name as the release title
  - Proper permissions configuration for writing release content

## Implementation Details
- The workflow uses `actions/github-script@v8` to implement custom polling logic for CI check validation
- Filters out the release job itself from the checks list to avoid circular dependencies
- Considers checks with `success`, `skipped`, or `neutral` conclusions as passing
- Provides detailed logging of check status (total, pending, failed counts)
- Uses the GitHub CLI (`gh release create`) for the final release creation with auto-generated notes

https://claude.ai/code/session_01BxWdrEQa6p3jGzGKZX4Wvt