### PR TITLE
Add Windows support with cross-platform test helper

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -41,7 +41,7 @@ func BenchmarkScheduledExecution(b *testing.B) {
 	for _, numLines := range []int{1, 10, 100, 1000} {
 		b.Run(fmt.Sprintf("%d-lines", numLines), func(b *testing.B) {
 			r, _ := newBenchReceiver(b)
-			r.cfg.Command = []string{"seq", fmt.Sprintf("%d", numLines)}
+			r.cfg.Command = helperCmd(b, "seq", fmt.Sprintf("%d", numLines))
 
 			require.NoError(b, r.startTelemetry())
 			b.Cleanup(func() { r.telemetry.Shutdown() })
@@ -59,7 +59,7 @@ func BenchmarkReceiverLifecycle(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		r, _ := newBenchReceiver(b)
-		r.cfg.Command = []string{"echo", "hello"}
+		r.cfg.Command = helperCmd(b, "echo", "hello")
 		r.cfg.Interval = time.Hour
 		require.NoError(b, r.Start(context.Background(), nil))
 		require.NoError(b, r.Shutdown(context.Background()))
@@ -70,7 +70,7 @@ func newBenchReceiver(b *testing.B) (*execReceiver, *consumertest.LogsSink) {
 	b.Helper()
 	sink := new(consumertest.LogsSink)
 	cfg := &Config{
-		Command:       []string{"echo", "hello"},
+		Command:       []string{"echo", "hello"}, // overridden by individual benchmarks
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,

--- a/cancel_unix.go
+++ b/cancel_unix.go
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package execreceiver // import "github.com/graphaelli/execreceiver"
+
+import (
+	"os"
+	"os/exec"
+)
+
+// cancelFunc returns a cancel function that sends SIGINT to the process.
+func cancelFunc(cmd *exec.Cmd) func() error {
+	return func() error {
+		return cmd.Process.Signal(os.Interrupt)
+	}
+}

--- a/cancel_windows.go
+++ b/cancel_windows.go
@@ -1,0 +1,17 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package execreceiver // import "github.com/graphaelli/execreceiver"
+
+import "os/exec"
+
+// cancelFunc returns a cancel function that kills the process.
+// Windows does not support SIGINT for arbitrary processes; Kill is the
+// portable way to terminate a child process.
+func cancelFunc(cmd *exec.Cmd) func() error {
+	return func() error {
+		return cmd.Process.Kill()
+	}
+}

--- a/internal/testhelper/main.go
+++ b/internal/testhelper/main.go
@@ -1,0 +1,143 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// testhelper is a cross-platform helper binary used in execreceiver tests.
+// It replaces shell-specific commands (sh, sleep, seq, printf, etc.) so that
+// tests run identically on Linux, macOS, and Windows.
+//
+// Usage: testhelper <subcommand> [args...]
+//
+//	echo <text...>               print args joined by space to stdout, exit 0
+//	echo-stderr <text...>        print args joined by space to stderr, exit 0
+//	echo-both <stdout> <stderr>  print first arg to stdout, second to stderr, exit 0
+//	echo-exit <text> <code>      print text to stdout, exit with code
+//	exit <code>                  exit with the given code, no output
+//	sleep <ms>                   sleep for N milliseconds, exit 0
+//	seq <n>                      print "line1" through "lineN" to stdout, exit 0
+//	multiline <a> <b> ...        print each arg on its own line, exit 0
+//	env <VAR>                    print the value of the named env var (or empty), exit 0
+//	pwd                          print the working directory, exit 0
+//	statefile <path>             state-machine: reads/writes an integer counter in <path>
+//	                             to produce deterministic output across 4 invocations
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: testhelper <subcommand> [args...]")
+		os.Exit(1)
+	}
+
+	switch os.Args[1] {
+	case "echo":
+		fmt.Println(strings.Join(os.Args[2:], " "))
+
+	case "echo-stderr":
+		fmt.Fprintln(os.Stderr, strings.Join(os.Args[2:], " "))
+
+	case "echo-both":
+		// echo-both <stdout-text> <stderr-text>
+		if len(os.Args) >= 4 {
+			fmt.Println(os.Args[2])
+			fmt.Fprintln(os.Stderr, os.Args[3])
+		}
+
+	case "echo-exit":
+		// echo-exit <text> <code>
+		if len(os.Args) >= 4 {
+			fmt.Println(os.Args[2])
+			code, _ := strconv.Atoi(os.Args[3])
+			os.Exit(code)
+		}
+
+	case "exit":
+		code, _ := strconv.Atoi(os.Args[2])
+		os.Exit(code)
+
+	case "sleep":
+		ms, _ := strconv.Atoi(os.Args[2])
+		time.Sleep(time.Duration(ms) * time.Millisecond)
+
+	case "seq":
+		n, _ := strconv.Atoi(os.Args[2])
+		for i := 1; i <= n; i++ {
+			fmt.Printf("line%d\n", i)
+		}
+
+	case "multiline":
+		for _, arg := range os.Args[2:] {
+			fmt.Println(arg)
+		}
+
+	case "env":
+		fmt.Println(os.Getenv(os.Args[2]))
+
+	case "pwd":
+		dir, err := os.Getwd()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Println(dir)
+
+	case "statefile":
+		// statefile <path>
+		// Implements a 4-step state machine used by TestStreamingBackoffResetsAfterSuccessfulRun.
+		// State is stored as an integer in the file at <path>.
+		//   0 (no file): print "run1-fail", write 1, exit 1
+		//   1:           print "run2-success", write 2, sleep 200ms, exit 0
+		//   2:           print "run3-after-reset", write 3, exit 1
+		//   3+:          print "run4-done", exit 1
+		if len(os.Args) < 3 {
+			fmt.Fprintln(os.Stderr, "statefile requires a path argument")
+			os.Exit(1)
+		}
+		path := os.Args[2]
+		state := readState(path)
+		switch state {
+		case 0:
+			fmt.Println("run1-fail")
+			writeState(path, 1)
+			os.Exit(1)
+		case 1:
+			fmt.Println("run2-success")
+			writeState(path, 2)
+			time.Sleep(200 * time.Millisecond)
+			os.Exit(0)
+		case 2:
+			fmt.Println("run3-after-reset")
+			writeState(path, 3)
+			os.Exit(1)
+		default:
+			fmt.Println("run4-done")
+			os.Exit(1)
+		}
+
+	default:
+		fmt.Fprintf(os.Stderr, "testhelper: unknown subcommand %q\n", os.Args[1])
+		os.Exit(1)
+	}
+}
+
+func readState(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func writeState(path string, state int) {
+	_ = os.WriteFile(path, []byte(strconv.Itoa(state)), 0o644)
+}

--- a/receiver.go
+++ b/receiver.go
@@ -427,10 +427,8 @@ func (r *execReceiver) readLines(reader io.Reader, stream string) []outputLine {
 func (r *execReceiver) buildCommand(ctx context.Context) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, r.cfg.Command[0], r.cfg.Command[1:]...)
 
-	// Graceful shutdown: send SIGINT first, then SIGKILL after 5s.
-	cmd.Cancel = func() error {
-		return cmd.Process.Signal(os.Interrupt)
-	}
+	// Graceful shutdown: send SIGINT on Unix, Kill on Windows; SIGKILL after 5s.
+	cmd.Cancel = cancelFunc(cmd)
 	cmd.WaitDelay = 5 * time.Second
 
 	if r.cfg.WorkingDirectory != "" {

--- a/receiver_test.go
+++ b/receiver_test.go
@@ -5,8 +5,8 @@ package execreceiver
 
 import (
 	"context"
-	"os"
-	"runtime"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,7 +30,7 @@ func newTestReceiver(t *testing.T, cfg *Config) (*execReceiver, *consumertest.Lo
 
 func TestScheduledBasic(t *testing.T) {
 	cfg := &Config{
-		Command:       []string{"echo", "hello"},
+		Command:       helperCmd(t, "echo", "hello"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour, // won't tick during test
 		MaxConcurrent: 1,
@@ -57,7 +57,8 @@ func TestScheduledBasic(t *testing.T) {
 
 	cmd, ok := lr.Attributes().Get("exec.command")
 	require.True(t, ok)
-	assert.Equal(t, "echo hello", cmd.Str())
+	assert.True(t, strings.HasSuffix(cmd.Str(), "echo hello"),
+		"exec.command should end with 'echo hello', got: %s", cmd.Str())
 
 	stream, ok := lr.Attributes().Get("exec.stream")
 	require.True(t, ok)
@@ -75,7 +76,7 @@ func TestScheduledBasic(t *testing.T) {
 
 func TestScheduledMultiLine(t *testing.T) {
 	cfg := &Config{
-		Command:       []string{"printf", "a\nb\nc"},
+		Command:       helperCmd(t, "multiline", "a", "b", "c"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -109,7 +110,7 @@ func TestScheduledMultiLine(t *testing.T) {
 
 func TestScheduledStderr(t *testing.T) {
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "echo error_output >&2"},
+		Command:       helperCmd(t, "echo-stderr", "error_output"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -137,7 +138,7 @@ func TestScheduledStderr(t *testing.T) {
 
 func TestScheduledStderrDisabled(t *testing.T) {
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "echo stdout_only && echo stderr_only >&2"},
+		Command:       helperCmd(t, "echo-both", "stdout_only", "stderr_only"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -171,7 +172,7 @@ func TestScheduledStderrDisabled(t *testing.T) {
 
 func TestScheduledCommandError(t *testing.T) {
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "exit 1"},
+		Command:       helperCmd(t, "exit", "1"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -190,11 +191,8 @@ func TestScheduledCommandError(t *testing.T) {
 }
 
 func TestScheduledTimeout(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("signal handling differs on windows")
-	}
 	cfg := &Config{
-		Command:       []string{"sleep", "60"},
+		Command:       helperCmd(t, "sleep", "60000"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		ExecTimeout:   500 * time.Millisecond,
@@ -214,7 +212,7 @@ func TestScheduledTimeout(t *testing.T) {
 
 func TestStreamingBasic(t *testing.T) {
 	cfg := &Config{
-		Command:         []string{"sh", "-c", "for i in 1 2 3; do echo line$i; done"},
+		Command:         helperCmd(t, "seq", "3"),
 		Mode:            ModeStreaming,
 		IncludeStderr:   true,
 		MaxBufferSize:   1024 * 1024,
@@ -249,7 +247,7 @@ func TestStreamingBasic(t *testing.T) {
 
 func TestStreamingRestart(t *testing.T) {
 	cfg := &Config{
-		Command:         []string{"sh", "-c", "echo restarted; exit 0"},
+		Command:         helperCmd(t, "echo", "restarted"),
 		Mode:            ModeStreaming,
 		IncludeStderr:   true,
 		MaxBufferSize:   1024 * 1024,
@@ -269,7 +267,7 @@ func TestStreamingRestart(t *testing.T) {
 
 func TestShutdownBeforeStart(t *testing.T) {
 	cfg := &Config{
-		Command:       []string{"echo", "hello"},
+		Command:       helperCmd(t, "echo", "hello"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -283,7 +281,7 @@ func TestShutdownBeforeStart(t *testing.T) {
 
 func TestEnvironment(t *testing.T) {
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "echo $TEST_VAR_EXEC"},
+		Command:       helperCmd(t, "env", "TEST_VAR_EXEC"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -306,9 +304,9 @@ func TestEnvironment(t *testing.T) {
 }
 
 func TestCleanEnvironmentByDefault(t *testing.T) {
-	// Default is inherit_environment: false, so HOME should not be set.
+	// Default is inherit_environment: false, so PATH should not be set.
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "echo ${HOME:-empty}"},
+		Command:       helperCmd(t, "env", "PATH"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -326,13 +324,13 @@ func TestCleanEnvironmentByDefault(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond)
 
 	lr := sink.AllLogs()[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
-	assert.Equal(t, "empty", lr.Body().Str())
+	assert.Equal(t, "", lr.Body().Str())
 }
 
 func TestInheritEnvironment(t *testing.T) {
-	// With inherit_environment: true, HOME should be inherited from the collector.
+	// With inherit_environment: true, PATH should be inherited from the collector.
 	cfg := &Config{
-		Command:            []string{"sh", "-c", "echo ${HOME:-empty}"},
+		Command:            helperCmd(t, "env", "PATH"),
 		Mode:               ModeScheduled,
 		Interval:           time.Hour,
 		MaxConcurrent:      1,
@@ -351,19 +349,20 @@ func TestInheritEnvironment(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond)
 
 	lr := sink.AllLogs()[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
-	assert.NotEqual(t, "empty", lr.Body().Str(), "HOME should be inherited from the collector environment")
+	assert.NotEmpty(t, lr.Body().Str(), "PATH should be inherited from the collector environment")
 }
 
 func TestWorkingDirectory(t *testing.T) {
+	dir := t.TempDir()
 	cfg := &Config{
-		Command:          []string{"pwd"},
+		Command:          helperCmd(t, "pwd"),
 		Mode:             ModeScheduled,
 		Interval:         time.Hour,
 		MaxConcurrent:    1,
 		IncludeStderr:    true,
 		MaxBufferSize:    1024 * 1024,
 		RestartDelay:     time.Second,
-		WorkingDirectory: "/tmp",
+		WorkingDirectory: dir,
 	}
 	r, sink := newTestReceiver(t, cfg)
 
@@ -375,17 +374,22 @@ func TestWorkingDirectory(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond)
 
 	lr := sink.AllLogs()[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
-	// /tmp may resolve to /private/tmp on macOS
 	body := lr.Body().Str()
-	assert.True(t, body == "/tmp" || body == "/private/tmp", "unexpected working directory: %s", body)
+
+	// Resolve symlinks to handle e.g. macOS /tmp → /private/tmp
+	evalDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		evalDir = dir
+	}
+	assert.True(t, body == dir || body == evalDir, "unexpected working directory: %s", body)
 }
 
 func TestScheduledMaxOutputSize(t *testing.T) {
 	// Generate output that exceeds the max_output_size limit.
-	// Each line is "line_NNN\n" = 9 bytes. With max_output_size=50,
-	// we can fit about 5 lines (5*9=45 <= 50), and the 6th (54) exceeds it.
+	// Each line from "seq 20" is "lineN\n" (6–8 bytes). With max_output_size=50,
+	// reading stops once totalBytes exceeds 50, leaving well under 20 lines.
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "for i in $(seq -w 1 20); do echo line_$i; done"},
+		Command:       helperCmd(t, "seq", "20"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -424,7 +428,7 @@ func TestScheduledMaxOutputSize(t *testing.T) {
 func TestScheduledMaxOutputSizeUnlimited(t *testing.T) {
 	// When max_output_size is 0, all output should be captured.
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "for i in 1 2 3 4 5; do echo line$i; done"},
+		Command:       helperCmd(t, "seq", "5"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -458,14 +462,11 @@ func TestScheduledMaxOutputSizeUnlimited(t *testing.T) {
 }
 
 func TestScheduledSkipOnConcurrencyLimit(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("sleep command differs on windows")
-	}
-	// Use a slow command (sleep 10) with a short interval and max_concurrent=1.
+	// Use a slow command (sleep 10s) with a short interval and max_concurrent=1.
 	// The first execution (triggered immediately on Start) will hold the
 	// semaphore for a long time. Subsequent ticks should be skipped.
 	cfg := &Config{
-		Command:       []string{"sleep", "10"},
+		Command:       helperCmd(t, "sleep", "10000"),
 		Mode:          ModeScheduled,
 		Interval:      100 * time.Millisecond,
 		MaxConcurrent: 1,
@@ -482,7 +483,7 @@ func TestScheduledSkipOnConcurrencyLimit(t *testing.T) {
 	// Ticks should be skipped because the semaphore is already held.
 	time.Sleep(500 * time.Millisecond)
 
-	// The semaphore should be full (1 slot occupied by sleep 10).
+	// The semaphore should be full (1 slot occupied by sleep).
 	// Verify that we cannot acquire the semaphore (it's full).
 	select {
 	case r.sem <- struct{}{}:
@@ -496,7 +497,7 @@ func TestScheduledSkipOnConcurrencyLimit(t *testing.T) {
 
 func TestScheduledInterval(t *testing.T) {
 	cfg := &Config{
-		Command:       []string{"echo", "tick"},
+		Command:       helperCmd(t, "echo", "tick"),
 		Mode:          ModeScheduled,
 		Interval:      200 * time.Millisecond,
 		MaxConcurrent: 1,
@@ -521,7 +522,7 @@ func TestStreamingBackoffIncreasesOnRapidFailures(t *testing.T) {
 	//   50ms, 100ms, 200ms (capped), 200ms, ...
 	// After 3 restarts (50+100+200=350ms minimum), we check timing.
 	cfg := &Config{
-		Command:         []string{"sh", "-c", "echo backoff; exit 1"},
+		Command:         helperCmd(t, "echo-exit", "backoff", "1"),
 		Mode:            ModeStreaming,
 		IncludeStderr:   true,
 		MaxBufferSize:   1024 * 1024,
@@ -560,47 +561,16 @@ func TestStreamingBackoffResetsAfterSuccessfulRun(t *testing.T) {
 	// If backoff reset works, runs 3+4 happen with short delays (50ms, 100ms).
 	// If backoff did NOT reset, run 3 would wait 200ms (doubled from 100ms).
 	//
-	// We verify by checking total time: with reset the total is roughly
-	// 50ms + 200ms + 50ms + 100ms = 400ms (plus execution time).
-	// Without reset it would be 50ms + 200ms + 200ms + 400ms = 850ms+.
-	//
-	// We use a state file to track which run we're on.
+	// State is tracked via a file managed by the testhelper "statefile" subcommand.
+	stateFile := filepath.Join(t.TempDir(), "state")
 	cfg := &Config{
-		Command: []string{"sh", "-c", `
-			if [ ! -f /tmp/execreceiver_backoff_test ]; then
-				echo "run1-fail"
-				touch /tmp/execreceiver_backoff_test
-				exit 1
-			elif [ ! -f /tmp/execreceiver_backoff_test2 ]; then
-				echo "run2-success"
-				touch /tmp/execreceiver_backoff_test2
-				sleep 0.2
-				exit 0
-			elif [ ! -f /tmp/execreceiver_backoff_test3 ]; then
-				echo "run3-after-reset"
-				touch /tmp/execreceiver_backoff_test3
-				exit 1
-			else
-				echo "run4-done"
-				exit 1
-			fi
-		`},
+		Command:         helperCmd(t, "statefile", stateFile),
 		Mode:            ModeStreaming,
 		IncludeStderr:   true,
 		MaxBufferSize:   1024 * 1024,
 		RestartDelay:    50 * time.Millisecond,
 		MaxRestartDelay: 5 * time.Second,
 	}
-
-	// Clean up state files before test.
-	_ = os.Remove("/tmp/execreceiver_backoff_test")
-	_ = os.Remove("/tmp/execreceiver_backoff_test2")
-	_ = os.Remove("/tmp/execreceiver_backoff_test3")
-	t.Cleanup(func() {
-		_ = os.Remove("/tmp/execreceiver_backoff_test")
-		_ = os.Remove("/tmp/execreceiver_backoff_test2")
-		_ = os.Remove("/tmp/execreceiver_backoff_test3")
-	})
 
 	r, sink := newTestReceiver(t, cfg)
 
@@ -643,7 +613,7 @@ func TestAuditLogScheduled(t *testing.T) {
 	core, observed := observer.New(zapcore.InfoLevel)
 
 	cfg := &Config{
-		Command:       []string{"echo", "hello"},
+		Command:       helperCmd(t, "echo", "hello"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -678,7 +648,8 @@ func TestAuditLogScheduled(t *testing.T) {
 	assert.Equal(t, zapcore.InfoLevel, entry.Level)
 
 	fields := fieldMap(entry.ContextMap())
-	assert.Equal(t, "echo hello", fields["command"])
+	assert.True(t, strings.HasSuffix(fields["command"].(string), "echo hello"),
+		"command should end with 'echo hello', got: %s", fields["command"])
 	assert.Equal(t, int64(0), fields["exit_code"])
 	assert.Equal(t, "scheduled", fields["mode"])
 	assert.Contains(t, fields, "pid")
@@ -690,7 +661,7 @@ func TestAuditLogScheduledNonZeroExit(t *testing.T) {
 	core, observed := observer.New(zapcore.InfoLevel)
 
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "exit 2"},
+		Command:       helperCmd(t, "exit", "2"),
 		Mode:          ModeScheduled,
 		Interval:      time.Hour,
 		MaxConcurrent: 1,
@@ -727,14 +698,15 @@ func TestAuditLogScheduledNonZeroExit(t *testing.T) {
 
 	fields := fieldMap(exitLog.ContextMap())
 	assert.Equal(t, int64(2), fields["exit_code"])
-	assert.Equal(t, "sh -c exit 2", fields["command"])
+	assert.True(t, strings.HasSuffix(fields["command"].(string), "exit 2"),
+		"command should end with 'exit 2', got: %s", fields["command"])
 }
 
 func TestAuditLogStreaming(t *testing.T) {
 	core, observed := observer.New(zapcore.InfoLevel)
 
 	cfg := &Config{
-		Command:       []string{"sh", "-c", "echo streaming_output; exit 0"},
+		Command:       helperCmd(t, "echo", "streaming_output"),
 		Mode:          ModeStreaming,
 		IncludeStderr: true,
 		MaxBufferSize: 1024 * 1024,

--- a/testhelper_test.go
+++ b/testhelper_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package execreceiver
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+var (
+	initTestHelper    sync.Once
+	testHelperBin     string
+	testHelperBuildErr error
+)
+
+// helperCmd returns a command slice that invokes the cross-platform test helper
+// binary with the given subcommand and arguments. The helper binary is compiled
+// once (lazily) the first time this function is called.
+//
+// Example: helperCmd(t, "echo", "hello") → []string{"/tmp/.../testhelper", "echo", "hello"}
+func helperCmd(tb testing.TB, args ...string) []string {
+	tb.Helper()
+	initTestHelper.Do(func() {
+		dir, err := os.MkdirTemp("", "execreceiver-testhelper-*")
+		if err != nil {
+			testHelperBuildErr = fmt.Errorf("creating temp dir: %w", err)
+			return
+		}
+
+		bin := filepath.Join(dir, "testhelper")
+		if runtime.GOOS == "windows" {
+			bin += ".exe"
+		}
+
+		cmd := exec.Command("go", "build", "-o", bin, "./internal/testhelper")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			testHelperBuildErr = fmt.Errorf("building testhelper: %w\n%s", err, out)
+			return
+		}
+		testHelperBin = bin
+	})
+
+	if testHelperBuildErr != nil {
+		tb.Fatalf("testhelper setup failed: %v", testHelperBuildErr)
+	}
+	return append([]string{testHelperBin}, args...)
+}

--- a/testhelper_test.go
+++ b/testhelper_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	initTestHelper    sync.Once
-	testHelperBin     string
+	initTestHelper     sync.Once
+	testHelperBin      string
 	testHelperBuildErr error
 )
 


### PR DESCRIPTION
Implements Windows support 

- Platform-specific signal handling (SIGINT on Unix, Kill on Windows)
- Cross-platform test helper binary replacing sh/sleep/seq/printf/pwd
- All tests rewritten to use the helper binary
- Windows skips removed from TestScheduledTimeout and TestScheduledSkipOnConcurrencyLimit
- Add windows to test matrix

Closes #13

Generated with [Claude Code](https://claude.ai/code)