### PR TITLE
Auto-trigger pr-fix on CI failure

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -1,0 +1,60 @@
+name: Auto Fix
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  auto-fix:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check for opt-out label and author association
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.workflow_run.pull_requests[0];
+            if (!pr) {
+              core.info('No pull request associated with this workflow run');
+              return;
+            }
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            if (pullRequest.labels.some(l => l.name === 'no-auto-fix')) {
+              core.info(`PR #${pr.number} has no-auto-fix label, skipping`);
+              return;
+            }
+
+            const allowed = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            if (!allowed.includes(pullRequest.author_association)) {
+              core.info(`PR #${pr.number} author association ${pullRequest.author_association} not allowed, skipping`);
+              return;
+            }
+
+            core.setOutput('pr_number', pr.number);
+
+      - name: Post /pr-fix comment
+        if: steps.check.outputs.pr_number
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.check.outputs.pr_number }},
+              body: '/pr-fix',
+            });


### PR DESCRIPTION
## Summary

- Adds a workflow that posts `/pr-fix` when CI fails on a PR
- Only triggers for repo maintainers (OWNER, MEMBER, COLLABORATOR)
- PRs with the `no-auto-fix` label are skipped
- Uses `workflow_run` event to detect CI completion, keeping this decoupled from the gh-aw pr-fix workflow

## Test plan

- [ ] Verify workflow triggers when CI fails on a maintainer's PR
- [ ] Verify `no-auto-fix` label prevents the comment from being posted
- [ ] Verify non-maintainer PRs are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)