### PR TITLE
Allow claude bot to trigger code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: 'claude'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary

- Adds `allowed_bots: 'claude'` to the claude-code-review workflow
- Fixes the "Workflow initiated by non-human actor: claude" error when Claude pushes commits to a PR and the `synchronize` event triggers the review workflow

## Context

https://github.com/graphaelli/execreceiver/actions/runs/22805626194?pr=20

🤖 Generated with [Claude Code](https://claude.com/claude-code)